### PR TITLE
Allow fixing of save files that have empty names.

### DIFF
--- a/ValheimCharacterEditor/Form1.cs
+++ b/ValheimCharacterEditor/Form1.cs
@@ -66,7 +66,7 @@ namespace ValheimCharacterEditor
 
         private void comboBox_Characters_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (Customization.FirstRun || String.IsNullOrEmpty(comboBox_Characters.SelectedItem.ToString()))
+            if (Customization.FirstRun || comboBox_Characters.SelectedIndex == -1 || comboBox_Characters.SelectedItem.ToString() == null)
             {
                 return;
             }        


### PR DESCRIPTION
I got an export of a character from a server and thought it turned out to have an empty string as a name that I wanted to fix.
Turns out this tool's select box rejects selecting a character with an empty-string name.